### PR TITLE
feat(auth): add points to AuthStore and update user data

### DIFF
--- a/frontend/client/landing/src/actions/index.ts
+++ b/frontend/client/landing/src/actions/index.ts
@@ -32,8 +32,8 @@ export const getStakerInfo = async (
 ) => {
   try {
     const {data} = await Axios.get(`referral?mode=getRef&address=${address}`)
-    const {status, data: d}: { data: T.getSelfRefResponse | string; status: number } = data
-    return status === 200 ? d as T.getSelfRefResponse : defaultRefResponse
+    const {status, data: d}: { data: T.getRefResponse | string; status: number } = data
+    return status === 200 ? d as T.getRefResponse : defaultRefResponse
   } catch (e) {
     console.log({e})
     return defaultRefResponse
@@ -48,5 +48,17 @@ export const getAuth = async (address: string) => {
   } catch (e) {
     console.log({e})
     return !!0
+  }
+}
+
+export const getStakersPoints = async (address: string) => {
+  try {
+    const {data} = await Axios.get(`referral?mode=getPoints&address=${address}`)
+    console.log({data})
+    const {status, data: d}: { data: number ; status: number } = data
+    return status === 200 ? d as number : 0
+  } catch (e) {
+    console.log({e})
+    return 0
   }
 }

--- a/frontend/client/landing/src/actions/newReferral.ts
+++ b/frontend/client/landing/src/actions/newReferral.ts
@@ -198,7 +198,7 @@ export const newReferral = async (form: T.refData) => {
             adminPay = {...adminPay, amount: String(amount)};
           }
           await Axios.post("referralPay", {adminPay, userPay});
-          await Axios.post("tx", {type: "levelTwo", amount, address, refBonus: {hasRef: !!0}});
+          await Axios.post("tx", {type: "levelTwo", amount, address, level: "two", refBonus: {hasRef: !!0}});
           localStorage.removeItem(refKey)
         }
         

--- a/frontend/client/landing/src/actions/newStake.ts
+++ b/frontend/client/landing/src/actions/newStake.ts
@@ -203,7 +203,7 @@ export const newStake = async (form: T.StakingData) => {
           if (Tx.data.result.status === "1") {
             //   dispatch(setTransactionState({ state: "payed" }));
             //   dispatch(saveStat({ type: "levelOne", amount }));
-            await Axios.post("tx", {type: "levelOne", amount, address, refBonus: {hasRef, address: fstUplineAddress}});
+            await Axios.post("tx", {type: "levelOne", amount, address, level: "one", refBonus: {hasRef, address: fstUplineAddress}});
             if (place !== "modal") updateBtnState("Confirmed")
             if (place === "modal") updateBtnStateTwo("Confirmed");
           }
@@ -211,7 +211,7 @@ export const newStake = async (form: T.StakingData) => {
           if (Tx.data.status === "1") {
             //   dispatch(setTransactionState({ state: "payed" }));
             //   dispatch(saveStat({ type: "levelOne", amount }));
-            await Axios.post("tx", {type: "levelOne", amount, address, refBonus: {hasRef, address: fstUplineAddress}});
+            await Axios.post("tx", {type: "levelOne", amount, address, level: "two", refBonus: {hasRef, address: fstUplineAddress}});
             if (place !== "modal") updateBtnState("Confirmed")
             if (place === "modal") updateBtnStateTwo("Confirmed");
           }

--- a/frontend/client/landing/src/app/api/referral/route.ts
+++ b/frontend/client/landing/src/app/api/referral/route.ts
@@ -11,22 +11,42 @@ export async function GET(request: NextRequest) {
   const refCode = request.nextUrl.searchParams.get("ref");
   const mode = request.nextUrl.searchParams.get("mode");
   
+  console.log({mode})
+  
   // console.log({ withCode, address, refCode });
   
   // try {
   let result, statusCode;
   if (address !== null) {
-    try {
-      const {data: d, status: s} = await ServerAxios.get(
-        `get-referral?ref=${address}`
-      );
-      result = d;
-      statusCode = s;
-    } catch (err) {
-      const e = (err as Error).message;
-      console.log({e})
-      result = "Not found";
-      statusCode = 404;
+    if (mode === "getPoints") {
+      try {
+        const rex = await ServerAxios.get(
+          `user?address=${address}&points=true`
+        );
+        console.log({rex})
+        const {data, status} = rex
+        console.log({data})
+        result = data.points;
+        statusCode = status;
+      } catch (err) {
+        const e = (err as Error).message;
+        console.log({e})
+        result = "No Address found";
+        statusCode = 404;
+      }
+    } else {
+      try {
+        const {data: d, status: s} = await ServerAxios.get(
+          `get-referral?ref=${address}`
+        );
+        result = d;
+        statusCode = s;
+      } catch (err) {
+        const e = (err as Error).message;
+        console.log({e})
+        result = "Not found";
+        statusCode = 404;
+      }
     }
   } else if (withCode !== null) {
     try {
@@ -74,7 +94,6 @@ export async function GET(request: NextRequest) {
         const {data, status} = await ServerAxios.get(
           `user?address=${address}`
         );
-        console.log({data})
         result = data;
         statusCode = status;
       } catch (err) {

--- a/frontend/client/landing/src/app/api/tx/route.ts
+++ b/frontend/client/landing/src/app/api/tx/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const body = await request.json();
 
-  const { address, type, amount, refBonus } = body;
+  const { address, type, amount, refBonus, level } = body;
 
   let result, statusCode;
 
@@ -51,6 +51,7 @@ export async function POST(request: NextRequest) {
       const { data: da } = await ServerAxios.post(`user`, {
         address,
         amount,
+        level
       });
       result = da;
     }

--- a/frontend/client/landing/src/components/molecules/Points.tsx
+++ b/frontend/client/landing/src/components/molecules/Points.tsx
@@ -3,10 +3,10 @@ import {useAuthStore} from "@/store/auth";
 import {Formatter} from "@/utils";
 
 export const Points = () => {
-  const user = useAuthStore((state) => state.user)
+  const points = useAuthStore((state) => state.points)
   return (
     <>
-      {user.points > 0 ? Formatter(user.points, {type: "d", decimalOptions: {n: 0, m: 0}}) : 0} pts
+      {points > 0 ? Formatter(points, {type: "d", decimalOptions: {n: 0, m: 0}}) : 0} pts
     </>
   );
 };

--- a/frontend/client/landing/src/components/organisms/LevelTwoTable.tsx~
+++ b/frontend/client/landing/src/components/organisms/LevelTwoTable.tsx~
@@ -9,7 +9,7 @@ import LevelTwoNewRefModal from "@/components/organisms/LevelTwoNewRefModal";
 import {Loader2} from "lucide-react";
 import {useUserContext} from "@/context/UserContext";
 
-const ReferralStats: FC<{ user: T.getRefResponse }> = ({user}) => {
+const ReferralStats: FC<{ user: T.getSelfRefResponse }> = ({user}) => {
   const {balLoading} = useUserContext()
   return (
     <div className="p-0 lg:px-8 lg:py-4 flex items-center justify-center">

--- a/frontend/client/landing/src/const/index.ts
+++ b/frontend/client/landing/src/const/index.ts
@@ -1,7 +1,7 @@
 import * as T from '@/types'
 import {v4 as uuidv4} from 'uuid';
 
-export const defaultRefResponse: T.getSelfRefResponse = {
+export const defaultRefResponse: T.getRefResponse = {
   id: 0,
   address: '',
   code: '',
@@ -15,7 +15,6 @@ export const defaultRefResponse: T.getSelfRefResponse = {
     secondLevel: 0,
     thirdLevel: 0,
   },
-  points: 0
 }
 
 export const demoNoti = (length: number) => Array.from({length}, (_, i) => ({

--- a/frontend/client/landing/src/context/UserContext.tsx
+++ b/frontend/client/landing/src/context/UserContext.tsx
@@ -1,7 +1,7 @@
 "use client"
 import {useWeb3Store} from "@/store";
 import {createContext, useContext, useEffect, useState} from "react";
-import {getReferrerProfits, getStakerInfo} from "@/actions";
+import {getReferrerProfits, getStakerInfo, getStakersPoints} from "@/actions";
 import {useAuthStore} from "@/store/auth";
 import {getProfit} from "@/functions";
 import * as T from "@/types"
@@ -24,6 +24,7 @@ const UserContext = createContext<UserContextType | undefined>(undefined);
 export const UserProvider = ({children}: { children: React.ReactNode }) => {
   const address = useWeb3Store((state) => state.address);
   const setUser = useAuthStore((state) => state.setUser)
+  const setPoints = useAuthStore((state) => state.setPoints)
   // const stakers = useGetStakers();
   const {stakeItems: stakers, stakesLoading} = useAuthContext()
   
@@ -31,6 +32,8 @@ export const UserProvider = ({children}: { children: React.ReactNode }) => {
   const getUserInfo = async () => {
     const res = await getStakerInfo(address)
     setUser(res)
+    const points = await getStakersPoints(address)
+    setPoints(points)
   }
   
   const [lvlOne, setLvlOne] = useState(0)

--- a/frontend/client/landing/src/store/auth.ts
+++ b/frontend/client/landing/src/store/auth.ts
@@ -9,11 +9,15 @@ export const useAuthStore = create<T.AuthStore>((set) => ({
   
   stakers: [],
   
+  points: 0,
+  
   user: defaultRefResponse,
   
   setIsAuth: (isAuth: boolean) => set({isAuth}),
   
-  setUser: (user: T.getSelfRefResponse) => set({user, ...user}),
+  setUser: (user: T.getRefResponse) => set({user, ...user}),
   
-  setStakers: (stakers: T.ParsedStakersData[]) => set({stakers})
+  setStakers: (stakers: T.ParsedStakersData[]) => set({stakers}),
+  
+  setPoints: (points: number) => set({points})
 }))

--- a/frontend/client/landing/src/types/interfaces.ts
+++ b/frontend/client/landing/src/types/interfaces.ts
@@ -132,17 +132,19 @@ export interface getRefByCodeResponse {
   status: number
 }
 
-export interface getSelfRefResponse extends getRefResponse {
+export interface PointResponse {
   points: number
 }
 
 export interface AuthStore {
   isAuth: boolean;
+  points: number;
   stakers: ParsedStakersData[] | []
-  user: getSelfRefResponse;
+  user: getRefResponse;
   setIsAuth: (isAuth: boolean) => void;
-  setUser: (user: getSelfRefResponse) => void;
+  setUser: (user: getRefResponse) => void;
   setStakers: (stakers: ParsedStakersData[]) => void;
+  setPoints: (points: number) => void;
 }
 
 export interface bscScan {


### PR DESCRIPTION
The changes made in this commit include:

1. Updating the `AuthStore` interface to include a `points` property and a `setPoints` function to manage the user's points.
2. Updating the `getRefResponse` interface to be renamed to `PointResponse` and including the `points` property.
3. Updating the `getUserInfo` function in the `UserContext` to fetch the user's points and update the `AuthStore` accordingly.
4. Updating the `Points` component to display the user's points from the `AuthStore` instead of the `user` object.
5. Updating the `newReferral` and `newStake` actions to include the `level` property when making the transaction request.

These changes were made to improve the user experience by displaying the user's points and updating the data structures to better represent the user's information.